### PR TITLE
Fix hero slider layout overflow and update controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -69,7 +69,7 @@ nav .container{display:flex;align-items:center;justify-content:space-between;pad
    ========================= */
 .home .hero-slider{
   position:relative;
-  width:100vw;              /* ensure full-bleed width */
+  width:100%;               /* prevent horizontal overflow on browsers with scrollbars */
   min-height:clamp(600px,88vh,960px);
   margin:0; padding:0; overflow:hidden;
 }
@@ -77,7 +77,7 @@ nav .container{display:flex;align-items:center;justify-content:space-between;pad
 .home .hero-slider .swiper,
 .home .hero-slider .swiper-wrapper,
 .home .hero-slider .swiper-slide {
-  width: 100vw;
+  width: 100%;
   height: clamp(560px, 88vh, 960px);
 }
 

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
   <main>
     <!-- HOME-ONLY: Hero Slideshow (namespaced, no conflicts) -->
     <!-- HOME-ONLY: Hero Slideshow -->
-<section class="hero-slider swiper">
+<section class="hero-slider swiper" data-autoplay-delay="6000" data-transition-speed="1200">
   <div class="swiper-wrapper">
 
     <!-- Slide 1 -->
@@ -168,8 +168,8 @@
   </div>
 
   <!-- Nav + pagination -->
-  <button class="hero-nav hero-prev" aria-label="Previous slide"><i class="fa-solid fa-chevron-left"></i></button>
-  <button class="hero-nav hero-next" aria-label="Next slide"><i class="fa-solid fa-chevron-right"></i></button>
+  <button class="hero-nav hero-prev" aria-label="Previous slide"><i class="fa-solid fa-circle-chevron-left"></i></button>
+  <button class="hero-nav hero-next" aria-label="Next slide"><i class="fa-solid fa-circle-chevron-right"></i></button>
   <div class="hero-pagination"></div>
 </section>
 

--- a/js/option6.js
+++ b/js/option6.js
@@ -94,13 +94,18 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // 2) Init Swiper
+    const sliderDelay = parseInt(heroEl.dataset.autoplayDelay, 10);
+    const sliderSpeed = parseInt(heroEl.dataset.transitionSpeed, 10);
+    const autoplayDelay = Number.isFinite(sliderDelay) ? sliderDelay : 6000;
+    const transitionSpeed = Number.isFinite(sliderSpeed) ? sliderSpeed : 1200;
+
     const heroSwiper = new Swiper(heroEl, {
       effect: 'fade',
       fadeEffect: { crossFade: true },
       loop: true,
-      speed: 900,
+      speed: transitionSpeed,
       autoplay: {
-        delay: 4500,
+        delay: autoplayDelay,
         disableOnInteraction: false,
         pauseOnMouseEnter: false // keep playing even when hovered
       },


### PR DESCRIPTION
## Summary
- prevent the home hero swiper from using 100vw widths that created a grey gutter in Chrome
- add data attributes and logic to configure hero slider autoplay delay and transition speed with longer defaults
- swap hero navigation icons for circle-chevron variants to match the requested style

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68e614bc4c548329ad2ba1c8027740c3