### PR TITLE
Fix installer transaction handling

### DIFF
--- a/install.php
+++ b/install.php
@@ -8,8 +8,6 @@ $errors = [];
 $message = '';
 
 try {
-    $pdo->beginTransaction();
-
     $pdo->exec('CREATE TABLE IF NOT EXISTS users (
         id INT AUTO_INCREMENT PRIMARY KEY,
         username VARCHAR(100) NOT NULL UNIQUE,
@@ -40,6 +38,8 @@ try {
         updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
         INDEX idx_parent_slug (parent_slug)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+
+    $pdo->beginTransaction();
 
     $adminExists = $pdo->query("SELECT COUNT(*) FROM users WHERE username = 'admin'")->fetchColumn();
     if (!$adminExists) {
@@ -93,7 +93,9 @@ try {
         ]);
     }
 
-    $pdo->commit();
+    if ($pdo->inTransaction()) {
+        $pdo->commit();
+    }
 
     if (!is_dir(__DIR__ . '/storage')) {
         mkdir(__DIR__ . '/storage', 0775, true);


### PR DESCRIPTION
## Summary
- move the installer transaction to start after the table DDL statements
- guard the commit call so it only runs when a transaction is active

## Testing
- php -l install.php

------
https://chatgpt.com/codex/tasks/task_e_68ef71aafeac8329a1638230ad4c725a