### PR TITLE
Replace TinyMCE integration with CKEditor super build

### DIFF
--- a/admin/includes/header.php
+++ b/admin/includes/header.php
@@ -10,7 +10,7 @@ require_admin();
   <title>Admin &mdash; Workplace Solutions</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-oBWdlEYUoMRn8DcRbTy9VnE3NQIdlZwIYdMb9RfMge+leP4YDbi0wzfopWn7UXQ8sGdzAFhlqmcuP5HTh3YtKQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="<?= base_url('admin/css/admin.css') ?>" />
-  <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
+  <script src="https://cdn.ckeditor.com/ckeditor5/39.0.1/super-build/ckeditor.js" referrerpolicy="origin"></script>
   <script src="<?= base_url('admin/js/admin.js') ?>" defer></script>
 </head>
 <body>

--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -1,17 +1,106 @@
 document.addEventListener('DOMContentLoaded', () => {
   const editorElements = document.querySelectorAll('.wysiwyg');
-  if (editorElements.length && window.tinymce) {
-    tinymce.init({
-      selector: '.wysiwyg',
-      height: 600,
-      plugins: 'link lists code table image media autoresize',
-      toolbar:
-        'undo redo | styleselect | bold italic underline | alignleft aligncenter alignright alignjustify | bullist numlist | link table | code',
-      menubar: 'file edit view insert format tools table help',
-      branding: false,
-      relative_urls: false,
-      remove_script_host: false,
-      convert_urls: false,
-    });
+
+  if (!editorElements.length || typeof window.ClassicEditor === 'undefined') {
+    return;
   }
+
+  editorElements.forEach((element) => {
+    window.ClassicEditor.create(element, {
+      toolbar: {
+        items: [
+          'heading',
+          '|',
+          'bold',
+          'italic',
+          'underline',
+          'strikethrough',
+          'link',
+          'bulletedList',
+          'numberedList',
+          '|',
+          'outdent',
+          'indent',
+          '|',
+          'blockQuote',
+          'insertTable',
+          'mediaEmbed',
+          'code',
+          'codeBlock',
+          'horizontalLine',
+          'removeFormat',
+          '|',
+          'undo',
+          'redo',
+        ],
+        shouldNotGroupWhenFull: true,
+      },
+      list: {
+        properties: {
+          styles: true,
+          startIndex: true,
+          reversed: true,
+        },
+      },
+      heading: {
+        options: [
+          { model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
+          { model: 'heading1', view: 'h1', title: 'Heading 1', class: 'ck-heading_heading1' },
+          { model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' },
+          { model: 'heading3', view: 'h3', title: 'Heading 3', class: 'ck-heading_heading3' },
+          { model: 'heading4', view: 'h4', title: 'Heading 4', class: 'ck-heading_heading4' },
+        ],
+      },
+      link: {
+        addTargetToExternalLinks: true,
+        decorators: {
+          toggleDownloadable: {
+            mode: 'manual',
+            label: 'Downloadable',
+            attributes: {
+              download: 'file',
+            },
+          },
+        },
+      },
+      table: {
+        contentToolbar: [
+          'tableColumn',
+          'tableRow',
+          'mergeTableCells',
+          'tableProperties',
+          'tableCellProperties',
+        ],
+      },
+      removePlugins: [
+        'AIAssistant',
+        'CKBox',
+        'CKFinder',
+        'EasyImage',
+        'ExportPdf',
+        'ExportWord',
+        'ImportWord',
+        'ImportPdf',
+        'RealTimeCollaborativeComments',
+        'RealTimeCollaborativeTrackChanges',
+        'RealTimeCollaborativeRevisionHistory',
+        'PresenceList',
+        'Comments',
+        'TrackChanges',
+        'TrackChangesData',
+        'RevisionHistory',
+        'Pagination',
+        'WProofreader',
+        'MathType',
+      ],
+    })
+      .then((editor) => {
+        editor.editing.view.change((writer) => {
+          writer.setStyle('min-height', '600px', editor.editing.view.document.getRoot());
+        });
+      })
+      .catch((error) => {
+        console.error('Error initializing the rich text editor', error);
+      });
+  });
 });


### PR DESCRIPTION
## Summary
- swap the TinyMCE CDN script for CKEditor 5 super-build so the admin editor no longer requires an API key
- initialize CKEditor on WYSIWYG fields with a feature-rich toolbar and remove premium plugins that would require licensing

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ef77a7643c83298b46807a2de30f74